### PR TITLE
Cleaned the layout a bit and got rid of the default percentage of 25

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def index():
         data = request.form['transcript']
         length= int(request.form['length'])
         print(length)
-        return render_template(r'index.html', data=summarize(str(data), length), prefill=data)
+        return render_template(r'index.html', data=summarize(str(data), length), prefill=data, size=length)
         # return text from the webpage
 
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def index():
         data = request.form['transcript']
         length= int(request.form['length'])
         print(length)
-        return render_template(r'index.html', data=summarize(str(data), length), prefill=data, size=length)
+        return render_template(r'index.html', data=summarize(str(data), length), prefill=data)
         # return text from the webpage
 
 

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -38,6 +38,4 @@ h4 {
     background-color: whitesmoke;
 }
 .size {
-    background-color: whitesmoke;
 }
-.

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -35,4 +35,9 @@ h4 {
 
 .input {
     width: 100%;
+    background-color: whitesmoke;
 }
+.size {
+    background-color: whitesmoke;
+}
+.

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,10 +18,10 @@
         <fieldset>
             <label>Transcript:</label>
             <div class = "full-width"></div>
-            <textarea name="transcript" rows="20" class="input" placeholder="Enter lecture summary here!">{{prefill}}</textarea>
+            <textarea name="transcript" rows="15" class="input" placeholder="Enter lecture summary here!">{{prefill}}</textarea>
             <div class = "full-width"></div>
             <div class = "summarizebtn">
-                Summarize to <input id="length" name="length" type="number" value="25">%
+                Summarize to <input id="length" name="length" type="number">%
             </div>
             <div class = "full-width"></div>
             <div class = "summarizebtn">
@@ -32,7 +32,10 @@
     </div>
   </div>
 
-<div class="summary"> {{data}} </div>
+<div class="summary"> 
+  <p>Summary: </p>
+  {{data}} 
+</div>
 </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,8 +20,10 @@
             <div class = "full-width"></div>
             <textarea name="transcript" rows="15" class="input" placeholder="Enter lecture summary here!">{{prefill}}</textarea>
             <div class = "full-width"></div>
-            <div class = "summarizebtn">
-                Summarize to <input id="length" name="length" type="number">%
+            <div>
+                Summarize to:
+                <br>
+                <input class="size" id="length" name="length" type="number">%
             </div>
             <div class = "full-width"></div>
             <div class = "summarizebtn">


### PR DESCRIPTION
I'm not sure if the percentage text box was left to a default of 25, is this done on purpose? Btw, cool work for the percentage input box, it's just that once you get up to a point like 60%, the summary length doesn't increase anymore. Should we set the percentage input to the minimum rather than the maximum in the future?
<img width="1275" alt="Screen Shot 2020-10-29 at 12 23 54" src="https://user-images.githubusercontent.com/68806999/97529264-1c1e8e80-19e2-11eb-94fe-c7c0af5f1c9d.png">
<img width="1275" alt="Screen Shot 2020-10-29 at 12 32 37" src="https://user-images.githubusercontent.com/68806999/97529609-de6e3580-19e2-11eb-8ad9-910482c6d239.png">

